### PR TITLE
feat: extend support for olive

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "tutor>=18.0.0,<19.0.0"
+    "tutor>=15.0.0,<16.0.0"
 ]
 
 optional-dependencies = { dev = ["python-semantic-release", "pylint", "black"]}

--- a/tutorcelery/hooks.py
+++ b/tutorcelery/hooks.py
@@ -23,5 +23,5 @@ class CELERY_WORKERS_ATTRS_TYPE(TypedDict):
 
 
 CELERY_WORKERS_CONFIG: Filter[dict[str, dict[str, CELERY_WORKERS_ATTRS_TYPE]], []] = (
-    Filter()
+    Filter('celery')
 )

--- a/tutorcelery/plugin.py
+++ b/tutorcelery/plugin.py
@@ -45,7 +45,6 @@ def _add_core_autoscaling_config(
     return scaling_config
 
 
-@tutor.hooks.lru_cache
 def get_celery_workers_config() -> dict[str, dict[str, CELERY_WORKERS_ATTRS_TYPE]]:
     """
     This function is cached for performance.


### PR DESCRIPTION
# Description
-  Release base: 18.3.0
- `hooks.lru_cache`: this decorator is removed because it's not supported in tutor 15. (Ref: https://github.com/overhangio/tutor/pull/996)
- `Filter('celery')`:  `celery` name is added because it's a mandatory parameter in tutor 15.